### PR TITLE
Updated version poser provider

### DIFF
--- a/src/IdeaBadge/Poser/Provider/PoserVersion.php
+++ b/src/IdeaBadge/Poser/Provider/PoserVersion.php
@@ -33,11 +33,11 @@ class PoserVersion implements PoserGeneratorInterface
             return $this->createBadge('n/a');
         }
 
-        if(!isset($json['updates'][0]['updateVersion'])) {
+        if(!isset($json['updates'][0]['version'])) {
             return $this->createBadge('n/a');
         }
 
-        return $this->createBadge($json['updates'][0]['updateVersion']);
+        return $this->createBadge($json['updates'][0]['version']);
     }
 
     /**

--- a/tests/Poser/Provider/Fixtures/updates.json
+++ b/tests/Poser/Provider/Fixtures/updates.json
@@ -12,7 +12,7 @@
       "notes": "",
       "size": "1MB",
       "sinceUntil": "145",
-      "updateVersion": "0.12.123",
+      "version": "0.12.123",
       "channel": "",
       "downloads": -1
     }


### PR DESCRIPTION
Hey,

I provided a small fix for the "Version" Poser provider. IntelliJ JSON response now contains "version" field instead of "updateVersion".

Best, Christian